### PR TITLE
fix import/no-unresolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "description": "Inline tool to change font family for Editor.js",
     "license": "MIT",
     "repository": "https://github.com/arwazjamal/editorjs-inline-font-family",
-    "main": "/dist/bundle.js",
+    "main": "./dist/bundle.js",
     "scripts": {
       "build": "webpack --mode production",
       "build:dev": "webpack --mode development --watch"


### PR DESCRIPTION
ESLint uses `main` key of `package.json` to locate the `bundle.js`. You had kept it `/dist...` which will make it search the `path` specified in config for the module, not the `dist` relative to current folder. This was resulting in import unresolved error. This PR fixes that. 

Similar to [this PR on your other repo](https://github.com/arwazjamal/editorjs-inline-font-size/pull/2). You may need to check your other repos if you've done the same thing.